### PR TITLE
Improve compatibility with chilled strings

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,7 +10,10 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        ruby: ["2.5", "2.6", "2.7", "3.0", "3.1", "3.2", "3.3", ruby-head, jruby-9.2, jruby-9.3, jruby-head]
+        ruby: ["2.5", "2.6", "2.7", "3.0", "3.1", "3.2", "3.3", "3.4", ruby-head, jruby-9.2, jruby-9.3, jruby-head]
+      include:
+        - ruby: "3.4"
+          rubyopt: "--enable-frozen-string-literal --debug-frozen-string-literal"
 
     steps:
     - uses: actions/checkout@v4
@@ -20,5 +23,5 @@ jobs:
         bundler-cache: true # 'bundle install' and cache gems
         ruby-version: ${{ matrix.ruby }}
         bundler: latest
-    - name: Run tests
-      run: bundle exec rake
+    - name: Run tests ${{ matrix.rubyopt }}
+      run: bundle exec rake RUBYOPT="${{ matrix.rubyopt }}"

--- a/Rakefile
+++ b/Rakefile
@@ -4,5 +4,5 @@ task :default => :spec
 
 desc "Run tests"
 task :spec do
-  sh 'bacon -a'
+  sh 'bin/bacon -a'
 end

--- a/bin/bacon
+++ b/bin/bacon
@@ -1,0 +1,488 @@
+#!/usr/bin/env ruby
+# frozen_string_literal: true
+# -*- ruby -*-
+
+# Bacon -- small RSpec clone.
+#
+# "Truth will sooner come out from error than from confusion." ---Francis Bacon
+
+# Copyright (C) 2007, 2008, 2012 Christian Neukirchen <purl.org/net/chneukirchen>
+#
+# Bacon is freely distributable under the terms of an MIT-style license.
+# See COPYING or http://www.opensource.org/licenses/mit-license.php.
+
+module Bacon
+  VERSION = "1.2"
+
+  Counter = Hash.new(0)
+  ErrorLog = +""
+  Shared = Hash.new { |_, name|
+    raise NameError, "no such context: #{name.inspect}"
+  }
+
+  RestrictName    = //  unless defined? RestrictName
+  RestrictContext = //  unless defined? RestrictContext
+
+  Backtraces = true  unless defined? Backtraces
+
+  def self.summary_on_exit
+    return  if Counter[:installed_summary] > 0
+    @timer = Time.now
+    at_exit {
+      handle_summary
+      if $!
+        raise $!
+      elsif Counter[:errors] + Counter[:failed] > 0
+        exit 1
+      end
+    }
+    Counter[:installed_summary] += 1
+  end
+  class <<self; alias summary_at_exit summary_on_exit; end
+
+  module SpecDoxOutput
+    def handle_specification(name)
+      puts spaces + name
+      yield
+      puts if Counter[:context_depth] == 1
+    end
+
+    def handle_requirement(description)
+      print "#{spaces}  - #{description}"
+      error = yield
+      puts error.empty? ? "" : " [#{error}]"
+    end
+
+    def handle_summary
+      print ErrorLog  if Backtraces
+      puts "%d specifications (%d requirements), %d failures, %d errors" %
+        Counter.values_at(:specifications, :requirements, :failed, :errors)
+    end
+
+    def spaces
+      "  " * (Counter[:context_depth] - 1)
+    end
+  end
+
+  module TestUnitOutput
+    def handle_specification(name)  yield  end
+
+    def handle_requirement(description)
+      error = yield
+      if error.empty?
+        print "."
+      else
+        print error[0..0]
+      end
+    end
+
+    def handle_summary
+      puts "", "Finished in #{Time.now - @timer} seconds."
+      puts ErrorLog  if Backtraces
+      puts "%d tests, %d assertions, %d failures, %d errors" %
+        Counter.values_at(:specifications, :requirements, :failed, :errors)
+    end
+  end
+
+  module TapOutput
+    def handle_specification(name)  yield  end
+
+    def handle_requirement(description)
+      ErrorLog.replace ""
+      error = yield
+      if error.empty?
+        puts "ok %-3d - %s" % [Counter[:specifications], description]
+      else
+        puts "not ok %d - %s: %s" %
+          [Counter[:specifications], description, error]
+        puts ErrorLog.strip.gsub(/^/, '# ')  if Backtraces
+      end
+    end
+
+    def handle_summary
+      puts "1..#{Counter[:specifications]}"
+      puts "# %d tests, %d assertions, %d failures, %d errors" %
+        Counter.values_at(:specifications, :requirements, :failed, :errors)
+    end
+  end
+
+  module KnockOutput
+    def handle_specification(name)  yield  end
+
+    def handle_requirement(description)
+      ErrorLog.replace ""
+      error = yield
+      if error.empty?
+        puts "ok - %s" % [description]
+      else
+        puts "not ok - %s: %s" % [description, error]
+        puts ErrorLog.strip.gsub(/^/, '# ')  if Backtraces
+      end
+    end
+
+    def handle_summary;  end
+  end
+
+  extend SpecDoxOutput          # default
+
+  class Error < RuntimeError
+    attr_accessor :count_as
+
+    def initialize(count_as, message)
+      @count_as = count_as
+      super message
+    end
+  end
+
+  class Context
+    attr_reader :name, :block
+
+    def initialize(name, &block)
+      @name = name
+      @before, @after = [], []
+      @block = block
+    end
+
+    def run
+      return  unless name =~ RestrictContext
+      Counter[:context_depth] += 1
+      Bacon.handle_specification(name) { instance_eval(&block) }
+      Counter[:context_depth] -= 1
+      self
+    end
+
+    def before(&block); @before << block; end
+    def after(&block);  @after << block; end
+
+    def behaves_like(*names)
+      names.each { |name| instance_eval(&Shared[name]) }
+    end
+
+    def it(description, &block)
+      return  unless description =~ RestrictName
+      block ||= lambda { should.flunk "not implemented" }
+      Counter[:specifications] += 1
+      run_requirement description, block
+    end
+
+    def should(*args, &block)
+      if Counter[:depth]==0
+        it('should '+args.first,&block)
+      else
+        super(*args,&block)
+      end
+    end
+
+    def run_requirement(description, spec)
+      Bacon.handle_requirement description do
+        begin
+          Counter[:depth] += 1
+          rescued = false
+          begin
+            @before.each { |block| instance_eval(&block) }
+            prev_req = Counter[:requirements]
+            instance_eval(&spec)
+          rescue Object => e
+            rescued = true
+            raise e
+          ensure
+            if Counter[:requirements] == prev_req and not rescued
+              raise Error.new(:missing,
+                              "empty specification: #{@name} #{description}")
+            end
+            begin
+              @after.each { |block| instance_eval(&block) }
+            rescue Object => e
+              raise e  unless rescued
+            end
+          end
+        rescue Object => e
+          ErrorLog << "#{e.class}: #{e.message}\n"
+          e.backtrace.find_all { |line| line !~ /bin\/bacon|\/bacon\.rb:\d+/ }.
+            each_with_index { |line, i|
+            ErrorLog << "\t#{line}#{i==0 ? ": #@name - #{description}" : ""}\n"
+          }
+          ErrorLog << "\n"
+
+          if e.kind_of? Error
+            Counter[e.count_as] += 1
+            e.count_as.to_s.upcase
+          else
+            Counter[:errors] += 1
+            "ERROR: #{e.class}"
+          end
+        else
+          ""
+        ensure
+          Counter[:depth] -= 1
+        end
+      end
+    end
+
+    def describe(*args, &block)
+      context = Bacon::Context.new(args.join(' '), &block)
+      (parent_context = self).methods(false).each {|e|
+        class<<context; self end.send(:define_method, e) {|*args| parent_context.send(e, *args)}
+      }
+      @before.each { |b| context.before(&b) }
+      @after.each { |b| context.after(&b) }
+      context.run
+    end
+
+    def raise?(*args, &block); block.raise?(*args); end
+    def throw?(*args, &block); block.throw?(*args); end
+    def change?(&block); lambda{}.change?(&block); end
+  end
+
+  module ColoredOutput
+    def handle_requirement(*args)
+      error = yield
+
+      print error.empty? ? color("\e[32m") : color("\e[1;31m")
+      super(*args) { error }
+      print color("\e[0m")
+    end
+
+    def color(escape_seq)
+      if $stdout.respond_to?(:tty?) && $stdout.tty?
+        escape_seq
+      else
+        ""
+      end
+    end
+  end
+
+  extend ColoredOutput
+end
+
+
+class Object
+  def true?; false; end
+  def false?; false; end
+end
+
+class TrueClass
+  def true?; true; end
+end
+
+class FalseClass
+  def false?; true; end
+end
+
+class Proc
+  def raise?(*exceptions)
+    call
+  rescue *(exceptions.empty? ? RuntimeError : exceptions) => e
+    e
+  else
+    false
+  end
+
+  def throw?(sym)
+    catch(sym) {
+      call
+      return false
+    }
+    return true
+  end
+
+  def change?
+    pre_result = yield
+    call
+    post_result = yield
+    pre_result != post_result
+  end
+end
+
+class Numeric
+  def close?(to, delta)
+    (to.to_f - self).abs <= delta.to_f  rescue false
+  end
+end
+
+
+class Object
+  def should(*args, &block)    Should.new(self).be(*args, &block)             end
+end
+
+module Kernel
+  private
+  def describe(*args, &block) Bacon::Context.new(args.join(' '), &block).run  end
+  def shared(name, &block)    Bacon::Shared[name] = block                     end
+end
+
+class Should
+  # Kills ==, ===, =~, eql?, equal?, frozen?, instance_of?, is_a?,
+  # kind_of?, nil?, respond_to?, tainted?
+  instance_methods.each { |name| undef_method name  if name =~ /\?|^\W+$/ }
+
+  def initialize(object)
+    @object = object
+    @negated = false
+  end
+
+  def not(*args, &block)
+    @negated = !@negated
+
+    if args.empty?
+      self
+    else
+      be(*args, &block)
+    end
+  end
+
+  def be(*args, &block)
+    if args.empty?
+      self
+    else
+      block = args.shift  unless block_given?
+      satisfy(*args, &block)
+    end
+  end
+
+  alias a  be
+  alias an be
+
+  def satisfy(description="", &block)
+    r = yield(@object)
+    if Bacon::Counter[:depth] > 0
+      Bacon::Counter[:requirements] += 1
+      raise Bacon::Error.new(:failed, description)  unless @negated ^ r
+      r
+    else
+      @negated ? !r : !!r
+    end
+  end
+
+  def method_missing(name, *args, &block)
+    name = "#{name}?"  if name.to_s =~ /\w[^?]\z/
+
+    desc = @negated ? "not ".dup : "".dup
+    desc << @object.inspect << "." << name.to_s
+    desc << "(" << args.map{|x|x.inspect}.join(", ") << ") failed"
+
+    satisfy(desc) { |x| x.__send__(name, *args, &block) }
+  end
+
+  def equal(value)         self == value      end
+  def match(value)         self =~ value      end
+  def identical_to(value)  self.equal? value  end
+  alias same_as identical_to
+
+  def flunk(reason="Flunked")
+    raise Bacon::Error.new(:failed, reason)
+  end
+end
+
+require 'optparse'
+$LOAD_PATH.unshift File.join(File.dirname(__FILE__), '../lib/')
+module Bacon; end
+
+automatic = false
+output = 'SpecDoxOutput'
+
+opts = OptionParser.new("", 24, '  ') { |opts|
+  opts.banner = "Usage: bacon [options] [files | -a] [-- untouched arguments]"
+
+  opts.separator ""
+  opts.separator "Ruby options:"
+
+  lineno = 1
+  opts.on("-e", "--eval LINE", "evaluate a LINE of code") { |line|
+    eval line, TOPLEVEL_BINDING, "-e", lineno
+    lineno += 1
+  }
+
+  opts.on("-d", "--debug", "set debugging flags (set $DEBUG to true)") {
+    $DEBUG = true
+  }
+  opts.on("-w", "--warn", "turn warnings on for your script") {
+    $-w = true
+  }
+
+  opts.on("-I", "--include PATH",
+          "specify $LOAD_PATH (may be used more than once)") { |path|
+    $LOAD_PATH.unshift(*path.split(":"))
+  }
+
+  opts.on("-r", "--require LIBRARY",
+          "require the library, before executing your script") { |library|
+    require library
+  }
+
+  opts.separator ""
+  opts.separator "bacon options:"
+
+  opts.on("-s", "--specdox", "do AgileDox-like output (default)") {
+    output = 'SpecDoxOutput'
+  }
+  opts.on("-q", "--quiet",   "do Test::Unit-like non-verbose output") {
+    output = 'TestUnitOutput'
+  }
+  opts.on("-p", "--tap",     "do TAP (Test Anything Protocol) output") {
+    output = 'TapOutput'
+  }
+  opts.on("-k", "--knock",   "do Knock output") {
+    output = 'KnockOutput'
+  }
+
+  opts.on("-o", "--output FORMAT",
+          "do FORMAT (SpecDox/TestUnit/Tap) output") { |format|
+    output = format + "Output" 
+  }
+  opts.on("-Q", "--no-backtrace", "don't print backtraces") {
+    Bacon.const_set :Backtraces, false
+  }
+
+  opts.on("-a", "--automatic", "gather tests from ./test/, include ./lib/") {
+    $LOAD_PATH.unshift "lib"  if File.directory? "lib"
+    automatic = true
+  }
+
+  opts.on('-n', '--name NAME', String,
+          "runs tests matching regexp NAME") { |n|
+    Bacon.const_set :RestrictName, Regexp.new(n)
+  }
+  
+  opts.on('-t', '--testcase TESTCASE', String,
+          "runs tests in TestCases matching regexp TESTCASE") { |t|
+    Bacon.const_set :RestrictContext, Regexp.new(t)
+  }
+
+  opts.separator ""
+  opts.separator "Common options:"
+
+  opts.on_tail("-h", "--help", "Show this message") do
+    puts opts
+    exit
+  end
+
+  opts.on_tail("--version", "Show version") do
+    require 'bacon'
+    puts "bacon #{Bacon::VERSION}"
+    exit
+  end
+
+  opts.parse! ARGV
+}
+
+files = ARGV
+
+if automatic
+  files.concat Dir["test/**/test_*.rb"]
+  files.concat Dir["test/**/spec_*.rb"]
+  files.concat Dir["spec/**/spec_*.rb"]
+  files.concat Dir["spec/**/*_spec.rb"]
+end
+
+if files.empty?
+  puts opts.banner
+  exit 1
+end
+
+Bacon.extend Bacon.const_get(output) rescue abort "No such formatter: #{output}"
+Bacon.summary_on_exit
+
+files.each { |file|
+  load file
+}

--- a/lib/rack/sanitizer.rb
+++ b/lib/rack/sanitizer.rb
@@ -196,7 +196,11 @@ module Rack
 
       def sanitize_string(input)
         if input.is_a? String
-          input = input.force_encoding(Encoding::UTF_8)
+          # Handle chilled strings
+          # Rack values aren't supposed to be frozen, but it's common in test suites.
+          input = +input
+
+          input.force_encoding(Encoding::UTF_8)
 
           if input.valid_encoding?
             input

--- a/rack-sanitizer.gemspec
+++ b/rack-sanitizer.gemspec
@@ -6,7 +6,7 @@ Gem::Specification.new do |gem|
   gem.authors       = ["Jean Boussier", "whitequark"]
   gem.license       = "MIT"
   gem.email         = ["jean.boussier@gmail.org"]
-  gem.description   = %{Rack::Sanitizer is a Rack middleware which cleans up } <<
+  gem.description   = %{Rack::Sanitizer is a Rack middleware which cleans up } +
                       %{invalid UTF8 characters in request URI and headers.}
   gem.summary       = "It is a mordernized and optimized fork of rack-utf8_sanitizer"
   gem.homepage      = "http://github.com/Shopify/rack-sanitizer"

--- a/test/test_sanitizer.rb
+++ b/test/test_sanitizer.rb
@@ -1,6 +1,5 @@
 # encoding:ascii-8bit
 
-require 'bacon/colored_output'
 require 'cgi'
 require 'rack/sanitizer'
 
@@ -31,7 +30,7 @@ describe Rack::Sanitizer do
 
   describe "with invalid host input" do
     it "sanitizes host entity (SERVER_NAME)" do
-      host   = "host\xD0".force_encoding('UTF-8')
+      host   = "host\xD0".dup.force_encoding(Encoding::UTF_8)
       env    = @app.({ "SERVER_NAME" => host })
       result = env["SERVER_NAME"]
 
@@ -42,8 +41,8 @@ describe Rack::Sanitizer do
 
   describe "with invalid UTF-8 input" do
     before do
-      @plain_input = "foo\xe0".force_encoding('UTF-8')
-      @uri_input   = "http://bar/foo%E0".force_encoding('UTF-8')
+      @plain_input = "foo\xe0".dup.force_encoding(Encoding::UTF_8)
+      @uri_input   = "http://bar/foo%E0".dup.force_encoding(Encoding::UTF_8)
     end
 
     behaves_like :does_sanitize_plain
@@ -52,7 +51,7 @@ describe Rack::Sanitizer do
 
   describe "with invalid, incorrectly percent-encoded UTF-8 URI input" do
     before do
-      @uri_input   = "http://bar/foo%E0\xe0".force_encoding('UTF-8')
+      @uri_input   = "http://bar/foo%E0\xe0".dup.force_encoding(Encoding::UTF_8)
     end
 
     behaves_like :does_sanitize_uri
@@ -100,8 +99,8 @@ describe Rack::Sanitizer do
 
   describe "with valid UTF-8 input" do
     before do
-      @plain_input = "foo bar лол".force_encoding('UTF-8')
-      @uri_input   = "http://bar/foo+bar+%D0%BB%D0%BE%D0%BB".force_encoding('UTF-8')
+      @plain_input = "foo bar лол".dup.force_encoding(Encoding::UTF_8)
+      @uri_input   = "http://bar/foo+bar+%D0%BB%D0%BE%D0%BB".dup.force_encoding(Encoding::UTF_8)
     end
 
     behaves_like :identity_plain
@@ -109,7 +108,7 @@ describe Rack::Sanitizer do
 
     describe "with URI characters from reserved range" do
       before do
-        @uri_input   = "http://bar/foo+%2F%3A+bar+%D0%BB%D0%BE%D0%BB".force_encoding('UTF-8')
+        @uri_input   = "http://bar/foo+%2F%3A+bar+%D0%BB%D0%BE%D0%BB".dup.force_encoding(Encoding::UTF_8)
       end
 
       behaves_like :identity_uri
@@ -118,7 +117,7 @@ describe Rack::Sanitizer do
 
   describe "with valid, not percent-encoded UTF-8 URI input" do
     before do
-      @uri_input   = "http://bar/foo+bar+лол".force_encoding('UTF-8')
+      @uri_input   = "http://bar/foo+bar+лол".dup.force_encoding(Encoding::UTF_8)
       @encoded     = "http://bar/foo+bar+#{CGI.escape("лол")}"
     end
 
@@ -167,7 +166,7 @@ describe Rack::Sanitizer do
 
   describe "with symbols in the env" do
     before do
-      @uri_input = "http://bar/foo%E0\xe0".force_encoding('UTF-8')
+      @uri_input = "http://bar/foo%E0\xe0".dup.force_encoding(Encoding::UTF_8)
     end
 
     it "sanitizes REQUEST_PATH with invalid UTF-8 URI input" do
@@ -183,7 +182,7 @@ describe Rack::Sanitizer do
 
   describe "with form data" do
     def request_env
-      @plain_input = "foo bar лол".force_encoding('UTF-8')
+      @plain_input = "foo bar лол".dup.force_encoding(Encoding::UTF_8)
       {
          "REQUEST_METHOD" => "POST",
          "CONTENT_TYPE" => "application/x-www-form-urlencoded;foo=bar",
@@ -193,7 +192,7 @@ describe Rack::Sanitizer do
     end
 
     def sanitize_form_data(request_env = request_env())
-      @uri_input = "http://bar/foo+%2F%3A+bar+%D0%BB%D0%BE%D0%BB".force_encoding('UTF-8')
+      @uri_input = "http://bar/foo+%2F%3A+bar+%D0%BB%D0%BE%D0%BB".dup.force_encoding(Encoding::UTF_8)
       @response_env = @app.(request_env)
       sanitized_input = @response_env['rack.input'].read
 
@@ -380,7 +379,7 @@ describe Rack::Sanitizer do
 
   describe "with custom content-type" do
     def request_env
-      @plain_input = "foo bar лол".force_encoding('UTF-8')
+      @plain_input = "foo bar лол".dup.force_encoding(Encoding::UTF_8)
       {
           "REQUEST_METHOD" => "POST",
           "CONTENT_TYPE" => "application/vnd.api+json",
@@ -390,7 +389,7 @@ describe Rack::Sanitizer do
     end
 
     def sanitize_data(request_env = request_env())
-      @uri_input = "http://bar/foo+%2F%3A+bar+%D0%BB%D0%BE%D0%BB".force_encoding('UTF-8')
+      @uri_input = "http://bar/foo+%2F%3A+bar+%D0%BB%D0%BE%D0%BB".dup.force_encoding(Encoding::UTF_8)
       @response_env = @app.(request_env)
       sanitized_input = @response_env['rack.input'].read
 
@@ -464,7 +463,7 @@ describe Rack::Sanitizer do
 
   describe "with custom strategy" do
     def request_env
-      @plain_input = "foo bar лол".force_encoding('UTF-8')
+      @plain_input = "foo bar лол".dup.force_encoding(Encoding::UTF_8)
       {
           "REQUEST_METHOD" => "POST",
           "CONTENT_TYPE" => "application/json",
@@ -474,7 +473,7 @@ describe Rack::Sanitizer do
     end
 
     def sanitize_data(request_env = request_env())
-      @uri_input = "http://bar/foo+%2F%3A+bar+%D0%BB%D0%BE%D0%BB".force_encoding('UTF-8')
+      @uri_input = "http://bar/foo+%2F%3A+bar+%D0%BB%D0%BE%D0%BB".dup.force_encoding(Encoding::UTF_8)
       @response_env = @app.(request_env)
       sanitized_input = @response_env['rack.input'].read
 
@@ -507,7 +506,7 @@ describe Rack::Sanitizer do
 
     it "accepts a proc as a strategy" do
       truncate = -> (input) do
-        'replace'.force_encoding(Encoding::UTF_8)
+        'replace'.dup.force_encoding(Encoding::UTF_8)
       end
 
       @app = Rack::Sanitizer.new(-> env { env }, strategy: truncate)


### PR DESCRIPTION
Make the test suite not trigger any chilled string warning and pass with frozen string literal enabled.
For that I had to vendor the test framework to patch it given it's abandoned. It would be good to migrate to minitest, but I don't expect this gem to need much change so it's not really worth the effort nor the risk of converting the test suite.

Then as a followup, I fix https://github.com/Shopify/rack-sanitizer/issues/3. This is one of the unfortunate false positive of the chilled string warnings, since we use two codepaths based on `.frozen?`.

@etiennebarrie 

